### PR TITLE
fix(messages): messages sent on N can be read starting from N + 1

### DIFF
--- a/src/_aegis/agent.py
+++ b/src/_aegis/agent.py
@@ -48,7 +48,6 @@ class Agent:
         self.action_cooldown = max(0, self.action_cooldown - Constants.COOLDOWN_TICK)
 
     def process_end_of_turn(self) -> None:
-        self.message_buffer.next_round(self.game.round + 1)
         self.game.game_pb.end_turn(self)
 
     def turn(self) -> None:

--- a/src/_aegis/game.py
+++ b/src/_aegis/game.py
@@ -91,6 +91,7 @@ class Game:
         self.team_info.add_lumens(Team.GOOBS, Constants.LUMENS_PER_ROUND)
         self.team_info.add_lumens(Team.VOIDSEERS, Constants.LUMENS_PER_ROUND)
         self.for_each_agent(self._run_turn)
+        self.rotate_message_buffers()
         self.activate_pending_drone_scans()
         self.game_pb.send_drone_scan_update(self._drone_scans)
         self.serialize_team_info()
@@ -98,6 +99,17 @@ class Game:
         self.serialize_drone_scans()
         self.game_pb.end_round()
         self.check_game_over()
+
+    def rotate_message_buffers(self) -> None:
+        """
+        Advance all agents' message buffers to the next round.
+
+        This commits any pending messages and ensures that all agents' buffers
+        are synchronized for the upcoming round.
+        """
+        for agent_id in self.agents:
+            agent = self.get_agent(agent_id)
+            agent.message_buffer.next_round(self.round + 1)
 
     def check_game_over(self) -> None:
         if self.round == self.world.rounds and self.reason is None:
@@ -413,6 +425,7 @@ class Game:
 
     def methods(self, ac: AgentController) -> MethodDict:
         return {
+            "AgentType": AgentType,
             "Direction": Direction,
             "Location": Location,
             "Rubble": Rubble,


### PR DESCRIPTION
## Description

Messages sent can't be read on the same round. They can only read read it starting N + 1.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Resolves #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/CPSC-383/aegis/blob/main/CONTRIBUTING.md) guidelines.
