### PR TITLE
refactor(survivor state): remove survivor state enum

### DIFF
--- a/src/_aegis_game/common/objects/survivor.py
+++ b/src/_aegis_game/common/objects/survivor.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from enum import Enum
 from typing import override
 
 from .world_object import WorldObject
@@ -16,11 +15,8 @@ class Survivor(WorldObject):
 
     """
 
-    def __init__(
-        self, survivor_id: int = -1, health: int = 1, state: State | None = None
-    ) -> None:
+    def __init__(self, survivor_id: int = -1, health: int = 1) -> None:
         super().__init__()
-        self._state: Survivor.State = state if state is not None else self.State.ALIVE
         self.id: int = survivor_id
         self.health: int = health
 
@@ -29,16 +25,10 @@ class Survivor(WorldObject):
         Check if the survivor is alive.
 
         Returns:
-            True if the survivor is ALIVE, False otherwise.
+            True if the survivor's health attribute is greather than zero, otherwise False.
 
         """
-        return self._state == self.State.ALIVE
-
-    def set_state(self, state: State) -> None:
-        self._state = state
-
-    def get_state(self) -> State:
-        return self._state
+        return self.health > 0
 
     @override
     def __str__(self) -> str:
@@ -47,7 +37,3 @@ class Survivor(WorldObject):
     @override
     def __repr__(self) -> str:
         return self.__str__()
-
-    class State(Enum):
-        ALIVE = 0
-        DEAD = 1

--- a/src/_aegis_game/game.py
+++ b/src/_aegis_game/game.py
@@ -383,12 +383,14 @@ class Game:
                     layer.health = max(0, layer.health - decay_rate)
 
                     if layer.health <= 0:
-                        layer.set_state(Survivor.State.DEAD)
                         LOGGER.info(f"Survivor {layer.id} died from health decay")
 
                     # Track health change for client (only once per survivor per round)
                     self.game_pb.add_survivor_health_update(
-                        cell.location, layer.id, layer.health, layer.get_state().value
+                        cell.location,
+                        layer.id,
+                        layer.health,
+                        is_alive=layer.health > 0,
                     )
 
     def save(self, survivor: Survivor, agent: Agent) -> None:

--- a/src/_aegis_game/game_pb.py
+++ b/src/_aegis_game/game_pb.py
@@ -202,7 +202,7 @@ class GamePb:
         self.drone_scans.append(pb_drone_scan)
 
     def add_survivor_health_update(
-        self, location: Location, survivor_id: int, new_health: int, new_state: int
+        self, location: Location, survivor_id: int, new_health: int, *, is_alive: bool
     ) -> None:
         """Add a survivor health update to be sent to the client."""
         pb_update = SurvivorHealthUpdate()
@@ -210,9 +210,7 @@ class GamePb:
         pb_update.location.y = location.y
         pb_update.survivor_id = survivor_id
         pb_update.new_health = new_health
-        pb_update.new_state = (
-            SurvivorState.ALIVE if new_state == 0 else SurvivorState.DEAD
-        )
+        pb_update.new_state = SurvivorState.ALIVE if is_alive else SurvivorState.DEAD
         self.survivor_health_updates.append(pb_update)
 
     def team_to_schema(self, team: Team) -> PbTeam:


### PR DESCRIPTION
## Description

Removed the `State` enum used to check if a survivor was dead or alive. 

Used the survivor `health` attribute to check instead.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Resolves #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

## Checklist

- [x] I've read the [CONTRIBUTING](https://github.com/CPSC-383/aegis/blob/main/CONTRIBUTING.md) guidelines.
