### PR TITLE
Turned off agent_types and custom agent count in MAS assignment template

### DIFF
--- a/src/_aegis_game/templates/mas/config/config.yaml
+++ b/src/_aegis_game/templates/mas/config/config.yaml
@@ -6,9 +6,9 @@ features:
   ALLOW_AGENT_PREDICTIONS: false # allows predicting images from saved survivors (enables the predict and read_pending_predictions command for agents)
   ALLOW_AGENT_MESSAGES: true # allows agents to send messages to each other (enables the send_message and read_messages command for agents)
   ALLOW_DRONE_SCAN: true # allows agents to scan the map for more information (enables the drone_scan command for agents)
-  ALLOW_AGENT_TYPES: true # allows agents to have different types: Commander, Medic, and Engineer (enables type-specific commands and functionality)
+  ALLOW_AGENT_TYPES: false # allows agents to have different types: Commander, Medic, and Engineer (enables type-specific commands and functionality)
   HIDDEN_MOVE_COSTS: false # hides the move costs from the agents, requiring exploration to discover them
-  ALLOW_CUSTOM_AGENT_COUNT: true # allows setting a custom number of agents to be spawned at the start of the game
+  ALLOW_CUSTOM_AGENT_COUNT: false # allows setting a custom number of agents to be spawned at the start of the game
   DEFAULT_AGENT_AMOUNT: 7 # the number of agents to spawn at the start of the game
   SURV_HEALTH_DECAY_RATE: 0 # How much health a survivor loses per round
   ADVANCED_SCORING_SYSTEM: false # Score calculated by normal score + alive agents on team


### PR DESCRIPTION
agent_types to false
allow_custom_agent_count to false (default 7)

## Description

Makes A2 setup simple for CPSC 383 F25

## Related Issue(s)

aegis init --type mas  (only allowed 1 agent to spawn as it had types on) didn't matter if gui allowed user to pick 7

## Checklist

- [ ] I've read the [CONTRIBUTING](https://github.com/AEGIS-GAME/aegis/blob/main/CONTRIBUTING.md) guidelines.
